### PR TITLE
prompt template title rename

### DIFF
--- a/src/components/editors/vanilla/components/editor/index.css
+++ b/src/components/editors/vanilla/components/editor/index.css
@@ -1,7 +1,6 @@
-
-.vanilla__editor-btn-container, 
+.vanilla__editor-btn-container,
 .vanilla__editor-title,
-.vanilla__editor{
+.vanilla__editor {
   width: 80%;
 }
 
@@ -23,7 +22,7 @@ div.vanilla__editor {
   transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
 }
 
-.vanilla__editor-container{
+.vanilla__editor-container {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -37,14 +36,20 @@ div.vanilla__editor-container h1 {
   height: 100%;
 }
 
-
-.vanilla__editor-container button.vanilla__floating-toolbar-button-base{
+.vanilla__editor-container button.vanilla__floating-toolbar-button-base {
   margin: 5px 0;
 }
 
-div.vanilla__editor[contenteditable=true]:empty:before{
+div.vanilla__editor[contenteditable="true"]:empty:before {
   content: attr(placeholder);
   pointer-events: none;
+  display: block; /* For Firefox */
+}
+
+h1.vanilla__editor-title[contenteditable="true"]:empty:before {
+  content: attr(placeholder);
+  pointer-events: none;
+  opacity: 0.2;
   display: block; /* For Firefox */
 }
 

--- a/src/components/editors/vanilla/components/editor/index.tsx
+++ b/src/components/editors/vanilla/components/editor/index.tsx
@@ -1,10 +1,25 @@
 import "./index.css";
 import FloatingToolBarPlugin from "../../plugins/FloatingToolBarPlugin";
-import { Link } from "react-router-dom";
+import { useRef } from "react";
+import { useNavigate } from "react-router-dom";
 
 // See: https://stackoverflow.com/a/62522080/5045091 for the reason why we need to use `suppressContentEditableWarning={true}`.
 
 export default function Editor({ title }: { title: string }) {
+  const navigate = useNavigate();
+  const titleRef = useRef<HTMLHeadingElement>(null);
+
+  function navigateToQuickflow() {
+    if (titleRef && titleRef.current) {
+      if (!titleRef.current.textContent) {
+        alert("Please Enter a Template Title");
+        titleRef.current.focus();
+        return;
+      }
+      navigate("/quickflow");
+    }
+  }
+
   return (
     <>
       <div
@@ -15,11 +30,11 @@ export default function Editor({ title }: { title: string }) {
           contentEditable="true"
           suppressContentEditableWarning={true}
           className="vanilla__editor-title"
+          placeholder={title}
           data-editors--vanilla-editor-target="title"
           data-action="focusout->editors--vanilla-editor#handleFocusOut"
-        >
-          {title}
-        </h1>
+          ref={titleRef}
+        />
         <div
           contentEditable={true}
           suppressContentEditableWarning={true}
@@ -27,16 +42,15 @@ export default function Editor({ title }: { title: string }) {
           placeholder="Import, paste or start typing..."
           data-editors--vanilla-editor-target="content"
           data-action="focusout->editors--vanilla-editor#handleFocusOut"
-        ></div>
+        />
         <div className="vanilla__editor-btn-container">
-          <Link to="/quickflow">
-            <button
-              className="vanilla__floating-toolbar-button-base"
-              type="button"
-            >
-              Use this template
-            </button>
-          </Link>
+          <button
+            className="vanilla__floating-toolbar-button-base"
+            type="button"
+            onClick={navigateToQuickflow}
+          >
+            Use this template
+          </button>
           <div className="vanilla__editor-word-count">
             <p>
               <span data-editors--vanilla-editor-target="charCount"></span>


### PR DESCRIPTION
alert users when title is empty and `use template` button is clicked

**Linear Ticket**: [WRT-118](https://linear.app/wrt/issue/WRT-118)

## Issue Summary

Implemented an alert that prompts users to rename the template title if they click on the 'Use Template' button while the title is still empty. 

## Checklist

- [x] I performed a self review before assigning others
- [x] I wrote enough tests where necessary
- [x] I selected at least one reviewer
- [x] I squashed my commits
- [x] My final squashed commit message is very detailed.

See [5 Useful Tips For A Better Commit Message](https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message)

## Additional Notes

You may include:

1. Screenshots (if necessary)
2. Important notes
3. Any update related to your changes you'd like to share with the team
